### PR TITLE
Functions expect Kelvin. Only convert to Celsius if needed

### DIFF
--- a/AirSeaFluxCode/AirSeaFluxCode.py
+++ b/AirSeaFluxCode/AirSeaFluxCode.py
@@ -380,10 +380,8 @@ class S88:
             self.rh = self.hum[1]
         elif self.hum[0] == 'Td':
             Td = self.hum[1]  # dew point temperature (K)
-            Td = np.where(Td < 200, np.copy(Td)+CtoK, np.copy(Td))
-            T = np.where(self.T < 200, np.copy(self.T)+CtoK, np.copy(self.T))
             esd = 611.21*np.exp(17.502*((Td-CtoK)/(Td-32.19)))
-            es = 611.21*np.exp(17.502*((T-CtoK)/(T-32.19)))
+            es = 611.21*np.exp(17.502*((self.T-CtoK)/(T-32.19)))
             self.rh = 100*esd/es
         elif self.hum[0] == "q":
             es = 611.21*np.exp(17.502*((self.T-CtoK)/(self.T-32.19)))
@@ -521,13 +519,13 @@ class S88:
                 assert SST_fl == "bulk", "input SST should be bulk with cool skin correction switched on for method "+self.meth
             else:
                 assert SST_fl == "skin", "input SST should be skin for method "+self.meth
+        self.T = T
+        self.SST = SST
         self.L = "tsrv" if L is None else L
         self.arr_shp = spd.shape
         self.nlen = len(spd)
         self.spd = spd
-        self.T = np.where(T < 200, np.copy(T)+CtoK, np.copy(T))
         self.hum = ['no', np.full(SST.shape, 80)] if hum is None else hum
-        self.SST = np.where(SST < 200, np.copy(SST)+CtoK, np.copy(SST))
         self.lat = np.full(self.arr_shp, 45) if lat is None else lat
         self.grav = gc(self.lat)
         self.P = np.full(self.nlen, 1013) if P is None else P
@@ -664,7 +662,7 @@ class Beljaars(C30):
 def AirSeaFluxCode(spd, T, SST, SST_fl, meth, lat=None, hum=None, P=None,
                    hin=18, hout=10, Rl=None, Rs=None, cskin=0, skin=None, wl=0,
                    gust=None, qmeth="Buck2", tol=None, maxiter=30, out=0,
-                   out_var=None, L=None):
+                   out_var=None, L=None, force_kelvin: bool = True):
     """
     Calculate turbulent surface fluxes using different parameterizations.
 
@@ -754,6 +752,8 @@ def AirSeaFluxCode(spd, T, SST, SST_fl, meth, lat=None, hum=None, P=None,
        Monin-Obukhov length definition options
        "tsrv"  : default
        "Rb" : following ecmwf (IFS Documentation cy46r1)
+    force_kelvin : bool
+        Force temperature conversion to Kelvin if SST or T values are < 200
 
     Returns
     -------
@@ -824,6 +824,12 @@ def AirSeaFluxCode(spd, T, SST, SST_fl, meth, lat=None, hum=None, P=None,
     | 2021: Simplified by E. Kent
     | 2024: Units corrected by J. Siddons
     """
+    if force_kelvin:
+        SST = np.where(SST < 200, SST + CtoK, SST)
+        T = np.where(T < 200, T + CtoK, T)
+        if hum is not None and hum[0] == "Td":
+            hum[1] = np.where(hum[1] < 200, hum[1] + CtoK, hum[1])
+
     logging.basicConfig(filename='flux_calc.log', filemode="w",
                         format='%(asctime)s %(message)s', level=logging.INFO)
     logging.captureWarnings(True)

--- a/AirSeaFluxCode/cs_wl_subs/coolskin.py
+++ b/AirSeaFluxCode/cs_wl_subs/coolskin.py
@@ -57,8 +57,8 @@ def cs(sst, d, rho, Rs, Rnl, cp, lv, usr, tsr, qsr, grav, opt):
         cool skin thickness           [m]
     """
     # coded following Saunders (1967) with lambda = 6
-    if (np.nanmin(sst) > 200):  # if sst in Kelvin convert to Celsius
-        sst = sst-CtoK
+    # Need temperature in Celsius
+    sst_c = sst-CtoK
     # ************  cool skin constants  *******
     # density of water, specific heat capacity of water, water viscosity,
     # thermal conductivity of water
@@ -69,7 +69,7 @@ def cs(sst, d, rho, Rs, Rnl, cp, lv, usr, tsr, qsr, grav, opt):
     Qnsol = shf+lhf+Rnl
     if opt == "C35":
         cpw = 4000
-        aw = 2.1e-5*np.power(sst+3.2, 0.79)
+        aw = 2.1e-5*np.power(sst_c+3.2, 0.79)
         # d = delta(aw, Qnsol, usr, grav, rho, opt)
         fs = 0.065+11*d-6.6e-5/d*(1-np.exp(-d/8.0e-4))  # eq. 17 F96
         # in F96 first term in eq. 17 is 0.137 insted of 0.065
@@ -77,7 +77,8 @@ def cs(sst, d, rho, Rs, Rnl, cp, lv, usr, tsr, qsr, grav, opt):
         Qb = aw*Q+0.026*np.minimum(lhf, 0)*cpw/lv  # eq. 8 F96
         d = delta(aw, Qb, usr, grav)
     elif opt == "ecmwf":
-        aw = np.maximum(1e-5, 1e-5*(sst-CtoK))
+        # aw = np.maximum(1e-5, 1e-5*(sst-CtoK))
+        aw = np.maximum(1e-5, 1e-5*sst_c)
         # d = delta(aw, Qnsol, usr, grav, rho, opt)
         for jc in range(4):
             # fraction of the solar radiation absorbed in layer delta eq. 8.153
@@ -131,13 +132,13 @@ def cs_C35(sst, rho, Rs, Rnl, cp, lv, delta, usr, tsr, qsr, grav):
         cool skin thickness           [m]
     """
     # coded following Saunders (1967) with lambda = 6
-    if np.nanmin(sst) > 200:  # if sst in Kelvin convert to Celsius
-        sst = sst-CtoK
+    # Need sst in Celsius
+    sst_c = sst-CtoK
     # ************  cool skin constants  *******
     # density of water, specific heat capacity of water, water viscosity,
     # thermal conductivity of water
     rhow, cpw, visw, tcw = 1022, 4000, 1e-6, 0.6
-    aw = 2.1e-5*np.power(np.maximum(sst+3.2, 0), 0.79)
+    aw = 2.1e-5*np.power(np.maximum(sst_c+3.2, 0), 0.79)
     bigc = 16*grav*cpw*np.power(rhow*visw, 3)/(np.power(tcw, 2)*np.power(
         rho, 2))
     Rns = 0.945*Rs  # albedo correction
@@ -147,7 +148,7 @@ def cs_C35(sst, rho, Rs, Rnl, cp, lv, delta, usr, tsr, qsr, grav):
     fs = 0.065+11*delta-6.6e-5/delta*(1-np.exp(-delta/8.0e-4))
     Q = Qnsol+Rns*fs
     Qb = aw*Q+0.026*np.minimum(lhf, 0)*cpw/lv
-    xlamx = 6*np.ones(sst.shape)
+    xlamx = 6*np.ones(sst_c.shape)
     xlamx = np.where(Qb > 0, 6, 6/(1+(bigc*np.abs(Qb)/usr**4)**0.75)**0.333)
     delta = np.where(
         Qb > 0, np.minimum(xlamx*visw/(np.sqrt(rho/rhow)*usr), 0.01),
@@ -190,8 +191,6 @@ def cs_ecmwf(rho, Rs, Rnl, cp, lv, usr, tsr, qsr, sst, grav):
         cool skin temperature correction [K]
 
     """
-    if np.nanmin(sst) < 200:  # if sst in Celsius convert to Kelvin
-        sst = sst+CtoK
     aw = np.maximum(1e-5, 1e-5*(sst-CtoK))
     Rns = 0.945*Rs  # (net solar radiation (albedo correction)
     shf = rho*cp*usr*tsr

--- a/AirSeaFluxCode/cs_wl_subs/cs_wl_subs.py
+++ b/AirSeaFluxCode/cs_wl_subs/cs_wl_subs.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-from ..util_subs import CtoK
 
 
 def delta(aw, Q, usr, grav):
@@ -72,8 +71,6 @@ def get_dqer(dter, sst, qsea, lv):
        humidity correction            [g/kg]
 
     """
-    if np.nanmin(sst) < 200:  # if sst in Celsius convert to Kelvin
-        sst = sst+CtoK
     wetc = 0.622*lv*qsea/(287.1*np.power(sst, 2))
     dqer = wetc*dter
     return dqer

--- a/AirSeaFluxCode/cs_wl_subs/warmlayer.py
+++ b/AirSeaFluxCode/cs_wl_subs/warmlayer.py
@@ -54,8 +54,6 @@ def wl_ecmwf(rho, Rs, Rnl, cp, lv, usr, tsr, qsr, sst, skt, dtc, grav):
         warm layer correction       [K]
 
     """
-    if np.nanmin(sst) < 200:  # if sst in Celsius convert to Kelvin
-        sst = sst+CtoK
     rhow, cpw, visw, rd0 = 1025, 4190, 1e-6, 3
     Rns = 0.945*Rs
     #  Previous value of dT / warm-layer, adapted to depth:

--- a/AirSeaFluxCode/dev/AirSeaFluxCode_dev.py
+++ b/AirSeaFluxCode/dev/AirSeaFluxCode_dev.py
@@ -410,11 +410,9 @@ class S88:
             self.rh = self.hum[1]
         elif self.hum[0] == 'Td':
             Td = self.hum[1]  # dew point temperature (K)
-            Td = np.where(Td < 200, np.copy(Td)+CtoK, np.copy(Td))
-            T = np.where(self.T < 200, np.copy(self.T)+CtoK, np.copy(self.T))
             # T = np.copy(self.T)
             esd = 611.21*np.exp(17.502*((Td-CtoK)/(Td-32.19)))
-            es = 611.21*np.exp(17.502*((T-CtoK)/(T-32.19)))
+            es = 611.21*np.exp(17.502*((self.T-CtoK)/(self.T-32.19)))
             self.rh = 100*esd/es
         elif self.hum[0] == "q":
             es = 611.21*np.exp(17.502*((self.T-CtoK)/(self.T-32.19)))
@@ -572,16 +570,16 @@ class S88:
             else:
                 assert SST_fl == "skin", "input SST should be skin for method "+self.meth
         self.L = "tsrv" if L is None else L
+        self.T = T
+        self.SST = SST
         self.arr_shp = spd.shape
         self.nlen = len(spd)
         self.spd = spd
         if self.meth == "NCAR":
             self.spd = np.maximum(np.copy(self.spd), 0.5)
-        self.T = np.where(T < 200, np.copy(T)+CtoK, np.copy(T))
         # if self.meth in ["NCAR", "ecmwf"]:
         #     self.T = np.maximum(self.T, 180)
         self.hum = ['no', np.full(SST.shape, 80)] if hum is None else hum
-        self.SST = np.where(SST < 200, np.copy(SST)+CtoK, np.copy(SST))
         self.lat = np.full(self.arr_shp, 45) if lat is None else lat
         self.grav = gc(self.lat)
         self.P = np.full(self.nlen, 1013) if P is None else P
@@ -683,7 +681,7 @@ class ecmwf(C30):
 def AirSeaFluxCode_dev(spd, T, SST, SST_fl, meth, lat=None, hum=None, P=None,
                        hin=18, hout=10, Rl=None, Rs=None, cskin=0, skin=None,
                        wl=0, gust=None, qmeth="Buck2", tol=None, maxiter=10,
-                       out=0, out_var=None, L=None):
+                       out=0, out_var=None, L=None, force_kelvin: bool = True):
     """
     Calculate turbulent surface fluxes using different parameterizations.
 
@@ -774,6 +772,8 @@ def AirSeaFluxCode_dev(spd, T, SST, SST_fl, meth, lat=None, hum=None, P=None,
            Monin-Obukhov length definition options
            "tsrv"  : default
            "Rb" : following ecmwf (IFS Documentation cy46r1)
+        force_kelvin : bool
+            Force temperature conversion to Kelvin if SST or T values are < 200
 
     Returns
     -------
@@ -839,6 +839,12 @@ def AirSeaFluxCode_dev(spd, T, SST, SST_fl, meth, lat=None, hum=None, P=None,
     2021 / Simplified by E. Kent
     2024 / Units corrected by J. Siddons
     """
+    if force_kelvin:
+        SST = np.where(SST < 200, SST + CtoK, SST)
+        T = np.where(T < 200, T + CtoK, T)
+        if hum is not None and hum[0] == "Td":
+            hum[1] = np.where(hum[1] < 200, hum[1] + CtoK, hum[1])
+
     logging.basicConfig(filename='flux_calc.log', filemode="w",
                         format='%(asctime)s %(message)s', level=logging.INFO)
     logging.captureWarnings(True)

--- a/AirSeaFluxCode/dev/flux_subs_dev.py
+++ b/AirSeaFluxCode/dev/flux_subs_dev.py
@@ -633,8 +633,6 @@ def get_gust_old(beta, Ta, usr, tsrv, zi, grav):
     -------
     ug : float        [m/s]
     """
-    if np.nanmax(Ta) < 200:  # convert to K if in Celsius
-        Ta = Ta+273.16
     # minus sign to allow cube root
     Bf = (-grav/Ta)*usr*tsrv
     ug = np.ones(np.shape(Ta))*0.2
@@ -669,8 +667,6 @@ def get_gust(beta, zi, ustb, Ta, usr, tsrv, grav):
     -------
     ug : float        [m/s]
     """
-    if np.nanmax(Ta) < 200:  # convert to K if in Celsius
-        Ta = Ta+273.16
     # minus sign to allow cube root
     Bf = (-grav/Ta)*usr*tsrv
     ug = np.ones(np.shape(Ta))*ustb

--- a/AirSeaFluxCode/flux_subs/gust.py
+++ b/AirSeaFluxCode/flux_subs/gust.py
@@ -40,8 +40,6 @@ def get_gust(beta, zi, ustb, Ta, usr, tsrv, grav):
     -------
     ug : float        [m/s]
     """
-    if np.nanmax(Ta) < 200:  # convert to K if in Celsius
-        Ta = Ta+273.16
     # minus sign to allow cube root
     Bf = (-grav/Ta)*usr*tsrv
     ug = np.ones(np.shape(Ta))*ustb

--- a/AirSeaFluxCode/hum_subs/humidity.py
+++ b/AirSeaFluxCode/hum_subs/humidity.py
@@ -68,10 +68,8 @@ def get_hum(hum, T, sst, P, qmeth):
         qsea = qsat_sea(sst, P, qmeth)  # surface water q [g/kg]
     elif hum[0] == 'Td':
         Td = hum[1]  # dew point temperature (K)
-        Td = np.where(Td < 200, np.copy(Td)+CtoK, np.copy(Td))
-        T = np.where(T < 200, np.copy(T)+CtoK, np.copy(T))
-        esd = 611.21*np.exp(17.502*((Td-273.16)/(Td-32.19)))
-        es = 611.21*np.exp(17.502*((T-273.16)/(T-32.19)))
+        esd = 611.21*np.exp(17.502*((Td-CtoK)/(Td-32.19)))
+        es = 611.21*np.exp(17.502*((T-CtoK)/(T-32.19)))
         RH = 100*esd/es
         qair = qsat_air(T, P, RH, qmeth)  # q of air [g/kg]
         qsea = qsat_sea(sst, P, qmeth)    # surface water q [g/kg]
@@ -107,10 +105,6 @@ def gamma(opt, sst, t, q, cp):
 
     """
     q = np.copy(q) / 1000  # convert to [kg/kg]
-    if np.nanmin(sst) < 200:  # if sst in Celsius convert to Kelvin
-        sst = sst+CtoK
-    if np.nanmin(t) < 200:  # if t in Celsius convert to Kelvin
-        t = t+CtoK
     if opt == "moist":
         t = np.maximum(t, 180)
         q = np.maximum(q,  1e-6)

--- a/AirSeaFluxCode/hum_subs/qsat.py
+++ b/AirSeaFluxCode/hum_subs/qsat.py
@@ -15,7 +15,6 @@
 import numpy as np
 
 from .vapor_pressure import VaporPressure
-from ..util_subs import CtoK
 
 
 def qsat_sea(T, P, qmeth):
@@ -25,7 +24,7 @@ def qsat_sea(T, P, qmeth):
     Parameters
     ----------
     T : float
-        temperature [$^\circ$\,C]
+        temperature [K]
     P : float
         pressure [mb]
     qmeth : str
@@ -36,9 +35,6 @@ def qsat_sea(T, P, qmeth):
     qs : float
         surface saturation specific humidity [g/kg]
     """
-    T = np.asarray(T)
-    if np.nanmin(T) > 200:  # if Ta in Kelvin convert to Celsius
-        T = T-CtoK
     ex = VaporPressure(T, P, 'liquid', qmeth)
     es = 0.98*ex  # reduction at sea surface
     qs = 622*es/(P-0.378*es)
@@ -53,7 +49,7 @@ def qsat_air(T, P, rh, qmeth):
     Parameters
     ----------
     T : float
-        temperature [$^\circ$\,C]
+        temperature [K]
     P : float
         pressure [mb]
     rh : float
@@ -67,8 +63,6 @@ def qsat_air(T, P, rh, qmeth):
         specific humidity [g/kg]
     """
     T = np.asarray(T)
-    if np.nanmin(T) > 200:  # if Ta in Kelvin convert to Celsius
-        T = T-CtoK
     es = VaporPressure(T, P, 'liquid', qmeth)
     em = 0.01*rh*es
     q = 622*em/(P-0.378*em)

--- a/AirSeaFluxCode/hum_subs/vapor_pressure.py
+++ b/AirSeaFluxCode/hum_subs/vapor_pressure.py
@@ -14,8 +14,10 @@
 
 import numpy as np
 
+from ..util_subs.utils import CtoK
 
-def VaporPressure(temp, P, phase, meth):
+
+def VaporPressure(T, P, phase, meth):
     """
     Calculate the saturation vapor pressure.
 
@@ -32,8 +34,8 @@ def VaporPressure(temp, P, phase, meth):
 
     Parameters
     ----------
-    temp : float
-        Temperature [C]
+    T : float
+        Temperature [K]
     phase : str
         'liquid' : Calculate vapor pressure over liquid water or
         'ice' : Calculate vapor pressure over ice
@@ -59,10 +61,9 @@ def VaporPressure(temp, P, phase, meth):
     P : float
         Saturation vapor pressure [hPa]
     """
-    Psat = np.zeros(temp.size)*np.nan
-    if np.nanmin(temp) > 200:  # if Ta in Kelvin convert to Celsius
-        temp = temp-273.16
-    T = np.copy(temp)+273.16  # Most formulas use T in [K]
+    Psat = np.zeros(T.size)*np.nan
+    # Some methods require Celsius
+    T_c = T-CtoK
     #  Formulas using [C] use the variable temp
     #  Calculate saturation pressure over liquid water
     if phase == 'liquid':
@@ -122,21 +123,21 @@ def VaporPressure(temp, P, phase, meth):
             """Source: Murray, F. W., On the computation of \
                          saturation vapor pressure, J. Appl. Meteorol., \
                          6, 203-204, 1967."""
-            Psat = np.power(10, 7.5*(temp)/(temp+237.5)+0.7858)
+            Psat = np.power(10, 7.5*(T_c)/(T_c+237.5)+0.7858)
             # Murray quotes this as the original formula and
-            Psat = 6.1078*np.exp(17.269388*temp/(temp+237.3))
+            Psat = 6.1078*np.exp(17.269388*T_c/(T_c+237.3))
             # this as the mathematical aquivalent in the form of base e.
         elif meth == 'Buck':
             """Bucks vapor pressure formulation based on Tetens formula.
             Source: Buck, A. L., New equations for computing vapor pressure and
             enhancement factor, J. Appl. Meteorol., 20, 1527-1532, 1981."""
-            Psat = (6.1121*np.exp(17.502*temp/(240.97+temp)) *
+            Psat = (6.1121*np.exp(17.502*T_c/(240.97+T_c)) *
                     (1.0007+(3.46e-6*P)))
         elif meth == 'Buck2':
             """Bucks vapor pressure formulation based on Tetens formula.
             Source: Buck Research, Model CR-1A Hygrometer Operating Manual,
             May 2012"""
-            Psat = (6.1121*np.exp((18.678-(temp)/234.5)*(temp)/(257.14+temp)) *
+            Psat = (6.1121*np.exp((18.678-(T_c)/234.5)*(T_c)/(257.14+T_c)) *
                     (1+1e-4*(7.2+P*(0.0320)+5.9e-6*np.power(T, 2))))
         elif meth == 'WMO':
             """Intended WMO formulation, originally published by Goff (1957)
@@ -153,7 +154,7 @@ def VaporPressure(temp, P, phase, meth):
                             0.78614)
         elif meth == 'WMO2018':
             """WMO 2018 edition. Annex 4.B, eq. 4.B.1, 4.B.2, 4.B.5 """
-            Psat = 6.112*np.exp(17.62*temp/(243.12+temp))*(1.0016+3.15e-6*P -
+            Psat = 6.112*np.exp(17.62*T_c/(243.12+T_c))*(1.0016+3.15e-6*P -
                                                            0.074/P)
         elif meth == 'Sonntag':
             """Source: Sonntag, D., Advancements in the field of hygrometry,
@@ -165,7 +166,7 @@ def VaporPressure(temp, P, phase, meth):
             """Source: Bolton, D., The computation of equivalent potential
             temperature, Monthly Weather Report, 108, 1046-1053, 1980.
             equation (10)"""
-            Psat = 6.112*np.exp(17.67*temp/(temp+243.5))
+            Psat = 6.112*np.exp(17.67*T_c/(T_c+243.5))
         elif meth == 'IAPWS':
             """Source: Wagner W. and A. Pruss (2002), The IAPWS formulation
             1995 for the thermodynamic properties of ordinary water substance
@@ -238,7 +239,7 @@ def VaporPressure(temp, P, phase, meth):
         elif meth == 'MagnusTetens':
             """Source: Murray, F. W., On the computation of saturation vapor
             pressure, J. Appl. Meteorol., 6, 203-204, 1967."""
-            Psat = np.power(10, 9.5*temp/(265.5+temp)+0.7858)
+            Psat = np.power(10, 9.5*T_c/(265.5+T_c)+0.7858)
             #  Murray quotes this as the original formula and
             Psat = 6.1078*np.exp(21.8745584*(T-273.16)/(T-7.66))
             # this as the mathematical aquivalent in the form of base e.
@@ -246,19 +247,19 @@ def VaporPressure(temp, P, phase, meth):
             """Bucks vapor pressure formulation based on Tetens formula.
             Source: Buck, A. L., New equations for computing vapor pressure and
             enhancement factor, J. Appl. Meteorol., 20, 1527-1532, 1981."""
-            Psat = (6.1115*np.exp(22.452*temp/(272.55+temp)) *
+            Psat = (6.1115*np.exp(22.452*T_c/(272.55+T_c)) *
                     (1.0003+(4.18e-6*P)))
         elif meth == 'Buck2':
             """Bucks vapor pressure formulation based on Tetens formula.
             Source: Buck Research, Model CR-1A Hygrometer Operating Manual,
             Sep 2001"""
-            Psat = (6.1115*np.exp((23.036-temp/333.7)*temp/(279.82+temp)) *
+            Psat = (6.1115*np.exp((23.036-T_c/333.7)*T_c/(279.82+T_c)) *
                     (1+1e-4*(2.2+P*(0.0383+6.4e-6*np.power(T, 2)))))
         elif meth == 'CIMO':
             """Source: Annex 4B, Guide to Meteorological Instruments and
             Methods of Observation, WMO Publication No 8, 7th edition, Geneva,
             2008. (CIMO Guide)"""
-            Psat = (6.112*np.exp(22.46*temp/(272.62+temp)) *
+            Psat = (6.112*np.exp(22.46*T_c/(272.62+T_c)) *
                     (1.0016+3.15e-6*P-0.074/P))
         elif meth in ('WMO', 'WMO2000'):
             """There is no typo issue in the WMO formulations for ice.
@@ -282,7 +283,7 @@ def VaporPressure(temp, P, phase, meth):
                           0.00728332*T)/100
 
         # s = np.where(temp > 0)
-        if np.where(temp > 0).size[0] >= 1:
+        if np.where(T_c > 0).size[0] >= 1:
             """Independent of the formula used for ice, use Hyland Wexler
             (water) for temperatures above freezing (see above).
             Source Hyland, R. W. and A. Wexler, Formulations for the
@@ -292,6 +293,6 @@ def VaporPressure(temp, P, phase, meth):
                             0.41764768e-4*np.power(T, 2) -
                             0.14452093e-7*np.power(T, 3) +
                             0.65459673e1*np.log(T))/100
-            Psat[np.where(temp > 0)] = Psat_w[np.where(temp > 0)]
+            Psat[np.where(T_c > 0)] = Psat_w[np.where(T_c > 0)]
 
     return Psat

--- a/AirSeaFluxCode/util_subs/utils.py
+++ b/AirSeaFluxCode/util_subs/utils.py
@@ -95,7 +95,7 @@ def visc_air(T):
     Parameters
     ----------
     Ta : float
-        air temperature [$^\circ$\,C]
+        air temperature [K]
 
     Returns
     -------
@@ -103,10 +103,9 @@ def visc_air(T):
         kinematic viscosity [m^2/s]
     """
     T = np.asarray(T)
-    if (np.nanmin(T) > 200):  # if Ta in Kelvin convert to Celsius
-        T = T-273.16
-    visa = 1.326e-5*(1+6.542e-3*T+8.301e-6*np.power(T, 2) -
-                     4.84e-9*np.power(T, 3))
+    T_c = T-CtoK  # Need Celsius (note this was -273.16)
+    visa = 1.326e-5*(1+6.542e-3*T_c+8.301e-6*np.power(T_c, 2) -
+                     4.84e-9*np.power(T_c, 3))
     return visa
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #17

Only time user input is potentially converted is in `AirSeaFluxCode.AirSeaFluxCode`, and that can be turned off.

All other functions assume the input temperatures are in Kelvin, where Celsius is required it is calculated as needed.

This behaviour is a breaking change.